### PR TITLE
fix: prevent error when navigating to an angular view back from an angularjs view

### DIFF
--- a/src/angular-hybrid.ts
+++ b/src/angular-hybrid.ts
@@ -117,21 +117,26 @@ export class UIViewNgUpgrade {
 
     // Expose getters on PARENT_INJECT for context (creation state) and fqn (view address)
     // These will be used by further nested UIView
-    Object.defineProperty(parent, "context", {
-      get: function() {
-        const data = ng1elem['inheritedData']('$uiView');
-        return (data && data.$cfg) ? data.$cfg.viewDecl.$context : registry.root();
-      },
-      enumerable: true
-    });
+    if (typeof parent.context === 'undefined') {
+      Object.defineProperty(parent, "context", {
+        get: function() {
+          const data = ng1elem['inheritedData']('$uiView');
+          return (data && data.$cfg) ? data.$cfg.viewDecl.$context : registry.root();
+        },
+        enumerable: true
+      });
+    }
+    
+    if (typeof parent.fqn === 'undefined') {
+      Object.defineProperty(parent, "fqn", {
+        get: function() {
+          const data = ng1elem['inheritedData']('$uiView');
+          return (data && data.$uiView) ? data.$uiView.fqn : null;
+        },
+        enumerable: true
+      });
+    }
 
-    Object.defineProperty(parent, "fqn", {
-      get: function() {
-        const data = ng1elem['inheritedData']('$uiView');
-        return (data && data.$uiView) ? data.$uiView.fqn : null;
-      },
-      enumerable: true
-    });
   }
 }
 


### PR DESCRIPTION
When navigating from an angular view to an angularjs view and then back again `TypeError: Cannot redefine property: context` is thrown. This appears to fix it.