### PR TITLE
Fix broken dependencies that cause npm 5 problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@uirouter/angular": "git://github.com/ui-router/angular#SNAPSHOT-20170612",
+    "@uirouter/angular": "1.0.0-beta.7",
     "@uirouter/angularjs": "^1.0.5",
     "@uirouter/core": "=5.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@uirouter/angular": "git://github.com/ui-router/angular#SNAPSHOT-20170612",
-    "@uirouter/angularjs": "git://github.com/angular-ui/ui-router#SNAPSHOT-20170612",
+    "@uirouter/angularjs": "^1.0.5",
     "@uirouter/core": "=5.0.4"
   },
   "peerDependencies": {
@@ -43,7 +43,7 @@
     "rxjs": "^5.0.0",
     "shx": "^0.2.2",
     "systemjs": "0.19.25",
-    "typescript": "^2.1.5",
+    "typescript": "~2.3.4",
     "webpack": "^1.13.1",
     "zone.js": "~0.6.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,22 +50,27 @@
   version "1.10.31"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-1.10.31.tgz#cebc68d369ded05344000a9b7bc62fcca7131de5"
 
-"@uirouter/angular@git://github.com/ui-router/angular#1.0.0-beta.6-hybrid-2.0.0-4":
-  version "1.0.0-beta.6-hybrid-2.0.0-4"
-  resolved "git://github.com/ui-router/angular#90590ddde94fe0c3c8908bccd525bc1b2751106e"
+"@uirouter/angular@1.0.0-beta.7":
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@uirouter/angular/-/angular-1.0.0-beta.7.tgz#0cffd27863d9adc7543402ecf83732f5e924a2b8"
   dependencies:
-    "@uirouter/core" "^5.0.1"
+    "@uirouter/core" "=5.0.4"
     "@uirouter/rx" "=0.4.1"
+    tslib "^1.7.1"
 
-"@uirouter/angularjs@git://github.com/angular-ui/ui-router#1.0.3-hybrid-2.0.0-5":
-  version "1.0.3-hybrid-2.0.0-5"
-  resolved "git://github.com/angular-ui/ui-router#f429ea3b40fdc85dfdd9e2808ef14c73c071184a"
+"@uirouter/angularjs@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@uirouter/angularjs/-/angularjs-1.0.5.tgz#ba559378ac981255f9a96212b7ef51fb82ec49b8"
   dependencies:
-    "@uirouter/core" "^5.0.3"
+    "@uirouter/core" "5.0.5"
 
-"@uirouter/core@=5.0.3", "@uirouter/core@^5.0.1", "@uirouter/core@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.3.tgz#e2b5b1e45190e20c67ba4e15c013de5d4e0ccab3"
+"@uirouter/core@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.5.tgz#4fafae8b89e1bee321b0ed32e69ab66547c055c6"
+
+"@uirouter/core@=5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.4.tgz#798b9ec0f2cf58b234cce75fa2634b4698a44aca"
 
 "@uirouter/rx@=0.4.1":
   version "0.4.1"
@@ -2056,6 +2061,10 @@ tsickle@^0.21.0:
     source-map "^0.5.6"
     source-map-support "^0.4.2"
 
+tslib@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -2070,9 +2079,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@^2.1.5:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+typescript@~2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.24"


### PR DESCRIPTION
This PR attempts to make `@uirouter/angular-hybrid` installable with `npm@5` by fixing some transient dependency issues:

1. Change `@uirouter/angularjs` dependency to `^1.0.5` from `#SNAPSHOT-20170612` git reference

2. Change `@uirouter/angular` dependency to `1.0.0-beta.7` from `#SNAPSHOT-20170612` git reference, as it was failing to be installed via yarn

3. Update typescript version, but fix to only `patch` version updates, as `typescript@2.4.1` is unable to compile `rxjs` typings file, due to a broken signature (https://github.com/ReactiveX/rxjs/issues/2539)