### PR TITLE
Depend on npm packages rather than github repos

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 scripts
 .*
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@uirouter/angular": "git://github.com/ui-router/angular#SNAPSHOT-20170612",
-    "@uirouter/angularjs": "git://github.com/angular-ui/ui-router#SNAPSHOT-20170612",
+    "@uirouter/angular": "=1.0.0-beta.7",
+    "@uirouter/angularjs": "^1.0.5",
     "@uirouter/core": "=5.0.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Having dependencies on npm packages means we can properly version the our dependencies and it will also avoid problem with accessing gits behind firewall.