### PR TITLE
feat(typings): add types for hybrid state declaration

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -3,12 +3,11 @@ import { Component, NgModule } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { BrowserModule } from '@angular/platform-browser';
-import { UIRouterModule } from '@uirouter/angular';
-import { UIRouterUpgradeModule } from '@uirouter/angular-hybrid';
+import { UIRouterUpgradeModule, UIRouterHybridModule, Ng2HybridStateDeclaration } from '@uirouter/angular-hybrid';
 import { UrlService} from '@uirouter/core';
 
 
-var app = angular.module('minimal', ['ui.router.upgrade']);
+const app = angular.module('minimal', ['ui.router.upgrade']);
 
 app.run(($stateRegistry, $urlService) => {
   $urlService.rules.initial({state: 'app'});
@@ -45,16 +44,7 @@ app.run(($stateRegistry, $urlService) => {
       name: 'app.ng2',
       component: Ng2Component,
   });
-
-  // nested route to ng2 component
-  $stateRegistry.register({
-      url: '/ng2',
-      name: 'app.ng2.ng2',
-      component: Ng2Component,
-  });
 });
-
-
 
 // An AngularJS component
 app.component('ng1Component', {
@@ -68,7 +58,7 @@ app.component('ng1Component', {
         console.log('ng1Component.$onInit()');
       }
     }
-})
+});
 
 // An Angular component
 @Component({
@@ -85,6 +75,12 @@ export class Ng2Component {
   }
 }
 
+const nestedState: Ng2HybridStateDeclaration = {
+  url: '/ng2',
+  name: 'app.ng2.ng2',
+  component: Ng2Component
+};
+
 // The root Angular module
 @NgModule({
   imports: [
@@ -94,7 +90,7 @@ export class Ng2Component {
     // Provides the @uirouter/angular-hybrid directives
     UIRouterUpgradeModule,
     // Provides the @uirouter/angular directives
-    UIRouterModule,
+    UIRouterHybridModule.forChild({ states: [nestedState]})
   ],
   declarations: [Ng2Component],
   entryComponents: [Ng2Component],

--- a/src/angular-hybrid.ts
+++ b/src/angular-hybrid.ts
@@ -15,6 +15,7 @@ import {
 import { $InjectorLike, Ng1ViewConfig } from '@uirouter/angularjs';
 
 import { UIRouterRx } from '@uirouter/rx';
+import { IUIRouterHybridModule } from './intefaces';
 
 /**
  * Create a ng1 module for the ng1 half of the hybrid application to depend on.
@@ -155,6 +156,8 @@ export function getParentUIViewInject(r: StateRegistry): ParentUIViewInject {
   return { fqn: null, context: r.root() };
 }
 
+export const UIRouterHybridModule: IUIRouterHybridModule = UIRouterModule as IUIRouterHybridModule;
+
 /**
  * This NgModule should be added to the root module of the hybrid app.
  */
@@ -182,7 +185,7 @@ export function getParentUIViewInject(r: StateRegistry): ParentUIViewInject {
 // Downgrade the UIViewNgUpgrade ng2 Component to an ng1 directive.
 // The directive is used in a (generated) view template by the (host) ng1 ui-router,
 // whenever it finds a view configured with a `component: <Ng2ComponentClass>`
-upgradeModule.directive("uiViewNgUpgrade", <any> downgradeComponent({ 
+upgradeModule.directive("uiViewNgUpgrade", <any> downgradeComponent({
   component: UIViewNgUpgrade,
   inputs: ['name']
 }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './angular-hybrid';
+export * from './intefaces';

--- a/src/intefaces.ts
+++ b/src/intefaces.ts
@@ -1,0 +1,38 @@
+import { ModuleWithProviders } from '@angular/core';
+import { Ng2StateDeclaration, RootModule, StatesModule, UIRouterModule } from '@uirouter/angular';
+import { Ng1StateTransitionHook } from '@uirouter/angularjs';
+import { IInjectable } from '@uirouter/core';
+
+export interface _Ng2HybridStateDeclaration extends Ng2StateDeclaration {
+  onExit?: any;
+  onRetain?: any;
+  onEnter?: any;
+}
+
+export interface _HybridStateModule extends StatesModule {
+  states?: any;
+}
+
+export interface _HybridRootModule extends RootModule {
+  states?: any
+}
+
+export interface Ng2HybridStateDeclaration extends _Ng2HybridStateDeclaration {
+  onEnter?: Ng1StateTransitionHook | IInjectable;
+  onRetain?: Ng1StateTransitionHook | IInjectable;
+  onExit?: Ng1StateTransitionHook | IInjectable;
+}
+
+export interface HybridStateModule extends _HybridStateModule {
+  states?: Ng2HybridStateDeclaration[];
+}
+
+export interface HybridRootModule extends _HybridRootModule {
+  states?: Ng2HybridStateDeclaration[];
+}
+
+export interface IUIRouterHybridModule extends UIRouterModule {
+  forRoot(config?: HybridRootModule): ModuleWithProviders
+
+  forChild(module?: HybridStateModule): ModuleWithProviders;
+}


### PR DESCRIPTION
This allows to create angular 2 routes in typescript without getting typing errors due to the caveat of having to write onEnter/OnExit... hooks in angularjs format.