### PR TITLE
Fixed line of code in Bootstrap the app section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ platformBrowserDynamic()
       urlService.sync();
     }
 
-    platformRef.injector.get < NgZone > NgZone.run(startUIRouter);
+    platformRef.injector.get<NgZone>(NgZone).run(startUIRouter);
   });
 ```
 


### PR DESCRIPTION
Fixed line of code in Bootstrap the app section of README.md that was syntactically incorrect.  Used code from https://github.com/ui-router/sample-app-angular-hybrid/blob/878095bc7ed1948bb8ebf6e67d77724354393455/app/main.ts