### PR TITLE
fix(package): mark package as having side-effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "entryFile": "src/index.ts"
     }
   },
+  "sideEffects": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/ui-router/angular-hybrid.git"


### PR DESCRIPTION
By adding `"sideEffects": true` to the package.json we are
telling ng-packagr that it should not apply the `"sideEffects": false`
mark to the package.json that is published to npm.

The result of a no-side-effect package is that the Angular CLI
buildOptmizer to mark top level components as "PURE", which
means that the subsequent production optimizations can remove
unused functions but is also safe to rename them.

AngularJS needs the names of components to remain stable
since it uses reflection over the source code to find the name
of components to instantiate.

Fixes https://github.com/ui-router/angular-hybrid/issues/382